### PR TITLE
Potential fix for code scanning alert no. 3: Flask app is run in debug mode

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -306,4 +306,5 @@ def logout():
 
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/dstencil/chirpstack-deployment-assistant/security/code-scanning/3](https://github.com/dstencil/chirpstack-deployment-assistant/security/code-scanning/3)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using an environment variable to control the debug mode. This way, we can enable debug mode during development and disable it in production without changing the code.

1. Modify the `app.run` call to use an environment variable to determine whether to run in debug mode.
2. Import the `os` module if it is not already imported.
3. Set the `debug` parameter based on the value of the environment variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
