### PR TITLE
Potential fix for code scanning alert no. 7: Uncontrolled data used in path expression

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -3,7 +3,7 @@ import grpc
 from chirpstack_api import api
 import csv
 import os
-
+from werkzeug.utils import secure_filename
 app = Flask(__name__)
 app.secret_key = "your_secret_key"
 
@@ -218,10 +218,13 @@ def upload_gateways():
 
     file = request.files['file']
     tenant_id = request.form['tenant_id']
-    filename = os.path.join("uploads", file.filename)
-    file.save(filename)
+    filename = secure_filename(file.filename)
+    filepath = os.path.normpath(os.path.join("uploads", filename))
+    if not filepath.startswith(os.path.abspath("uploads")):
+        return jsonify({"error": "Invalid file path"}), 400
+    file.save(filepath)
 
-    with open(filename, "r") as csvfile:
+    with open(filepath, "r") as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
             create_gateway(tenant_id, row)


### PR DESCRIPTION
Potential fix for [https://github.com/dstencil/chirpstack-deployment-assistant/security/code-scanning/7](https://github.com/dstencil/chirpstack-deployment-assistant/security/code-scanning/7)

To fix the problem, we need to ensure that the `filename` derived from user input is safe and does not allow path traversal attacks. We can achieve this by normalizing the path and ensuring it is contained within the "uploads" directory. Additionally, we can use the `werkzeug.utils.secure_filename` function to sanitize the filename.

1. Import the `secure_filename` function from `werkzeug.utils`.
2. Use `secure_filename` to sanitize the filename.
3. Normalize the path using `os.path.normpath`.
4. Ensure the normalized path starts with the "uploads" directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
