### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -147,10 +147,11 @@ def upload_devices():
     file = request.files['file']
     tenant_id = request.form['tenant_id']
     application_id = request.form['application_id']
-    filename = os.path.join("uploads", file.filename)
-    file.save(filename)
+    filename = secure_filename(file.filename)
+    filepath = os.path.join("uploads", filename)
+    file.save(filepath)
 
-    with open(filename, "r") as csvfile:
+    with open(filepath, "r") as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
             create_device(tenant_id, application_id, row)


### PR DESCRIPTION
Potential fix for [https://github.com/dstencil/chirpstack-deployment-assistant/security/code-scanning/5](https://github.com/dstencil/chirpstack-deployment-assistant/security/code-scanning/5)

To fix the problem, we need to ensure that the filename derived from user input is safe to use. This can be achieved by using the `secure_filename` function from `werkzeug.utils`, which sanitizes the filename by removing any potentially dangerous characters. Additionally, we should ensure that the file is saved within a designated directory to prevent any path traversal attacks.

- Use `secure_filename` to sanitize the filename.
- Construct the full path using the sanitized filename.
- Ensure the file is saved within the "uploads" directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
